### PR TITLE
Add support for scoped packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 target
 *.iml
+.classpath
+.settings
+.project

--- a/src/it/basic/pom.xml
+++ b/src/it/basic/pom.xml
@@ -20,9 +20,9 @@
                         </goals>
                         <configuration>
                             <packages>
-                                <package>brunch:1.4.4</package>
-                                <package>less:1.3.0</package>
-                                <package>recess:1.1.6</package>
+                                <package>colors:~1.1.0</package>
+                                <package>underscore</package>
+                                <package>jshint:^0.7.0</package>
                             </packages>
                         </configuration>
                     </execution>

--- a/src/it/basic/verify.groovy
+++ b/src/it/basic/verify.groovy
@@ -6,7 +6,7 @@
  * LICENSE.txt file.
  */
 
-def modules = ["abbrev", "colors", "less", "nopt", "recess", "underscore", "watch"];
+def modules = ["colors", "jshint", "underscore"];
 
 modules.each() {
     def f = new File(basedir, "src/main/resources/META-INF/" + it)

--- a/src/main/java/org/mule/tools/npm/NPMMojo.java
+++ b/src/main/java/org/mule/tools/npm/NPMMojo.java
@@ -22,7 +22,7 @@ import java.io.File;
  */
 public class NPMMojo extends AbstractJavascriptMojo {
 
-    private static final String NPM_REPO_URL_TAIL = "%s/%s";
+    private static final String NPM_REPO_URL_TAIL = "%s";
 
     /**
      * Where the resulting files will be downloaded.

--- a/src/test/java/org/mule/tools/npm/NPMModuleTest.java
+++ b/src/test/java/org/mule/tools/npm/NPMModuleTest.java
@@ -10,6 +10,7 @@ package org.mule.tools.npm;
 
 
 import org.apache.maven.plugin.logging.Log;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -21,16 +22,21 @@ import static org.mockito.Mockito.mock;
 
 public class NPMModuleTest {
 
+	@Before
+	public void setUp() {
+		NPMModule.npmUrl = "http://registry.npmjs.org/%s";
+	}
+	
     @Test
-    public void testDownloadLess() throws Exception {
-        NPMModule npmModule = NPMModule.fromNameAndVersion(mock(Log.class), "less", "1.0.32");
-        npmModule.saveToFile(new File("target/less-test"));
+    public void testDownloadColors() throws Exception {
+        NPMModule npmModule = NPMModule.fromNameAndVersion(mock(Log.class), "colors", "1.1.2");
+        npmModule.saveToFile(new File("target/colors-test"));
     }
 
     @Test
-    public void testDownloadRecess() throws Exception {
-        NPMModule npmModule2 = NPMModule.fromName(mock(Log.class), "recess");
-        npmModule2.saveToFileWithDependencies(new File("target/recess-test"));
+    public void testDownloadUnderscore() throws Exception {
+        NPMModule npmModule2 = NPMModule.fromName(mock(Log.class), "underscore");
+        npmModule2.saveToFileWithDependencies(new File("target/underscore-test"));
     }
 
     @Test


### PR DESCRIPTION
There is a problem accessing metadata for scoped packages from the npm
registry.  You can get the root level metadata for the package, but not
by version.  There doesn’t seem to be plans to support it either.  See
the following npm issue: https://github.com/npm/npm/issues/9164

These code changes swap the approach from accessing a package data from
the version level e.g. http://registry.npmjs.org/colors/1.1.2 to the
root level e.g. http://registry.npmjs.org/colors and then parsing the
json for the correct data.

It also fixes the tests by moving to later versions of modules that
correctly reference newer semver principles.
